### PR TITLE
Tweak adding 'the' to `<name> was declared the winner at the end of <round>`

### DIFF
--- a/src/main/scala/com/gu/ballot/av/Round.scala
+++ b/src/main/scala/com/gu/ballot/av/Round.scala
@@ -53,7 +53,7 @@ case class Round(countByPreference: Map[Preference, Int]) {
   }
 
   lazy val outcomeSummary: String = outcome match {
-    case ClearWinner(winner) => s"$winner was declared winner"
+    case ClearWinner(winner) => s"$winner was declared the winner"
     case elimination: Elimination => s"${elimination.eliminatedCandidates.wasOrWere} eliminated"
     case essentialTie: EssentialTie => "there was an essential tie."
   }


### PR DESCRIPTION
As suggested by @CPKING!

```
Most tiny typo in the following sentence:

'Consequently, Mollie Peck was declared winner at the end of round 4.'

I'd change that to '<name> was declared the winner at the end of <round>.
```
